### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/QQB_CHAT_MESSAGES_SMS.html
+++ b/QQB_CHAT_MESSAGES_SMS.html
@@ -230,10 +230,14 @@
                 var messagesDiv = document.getElementById('messages');
                 var userMessageDiv = document.createElement('div');
                 userMessageDiv.className = 'message user-message';
-                userMessageDiv.innerHTML = `
-                    <div class="message-content">${userInput.value}</div>
-                    <div class="timestamp">${getCurrentTime()}</div>
-                `;
+                const userMessageContent = document.createElement('div');
+                userMessageContent.className = 'message-content';
+                userMessageContent.textContent = userInput.value;
+                const userMessageTimestamp = document.createElement('div');
+                userMessageTimestamp.className = 'timestamp';
+                userMessageTimestamp.textContent = getCurrentTime();
+                userMessageDiv.appendChild(userMessageContent);
+                userMessageDiv.appendChild(userMessageTimestamp);
                 messagesDiv.appendChild(userMessageDiv);
 
                 document.getElementById('bot-typing').style.display = "block";

--- a/qr_11.html
+++ b/qr_11.html
@@ -596,12 +596,17 @@
 
                             const button = document.createElement('button');
                             button.className = 'selected-service-btn';
-                            button.innerHTML = `${specificService} <span class="remove-service">×</span>`;
-                            button.querySelector('.remove-service').addEventListener('click', function(event) {
+                            button.textContent = specificService;
+
+                            const removeSpan = document.createElement('span');
+                            removeSpan.className = 'remove-service';
+                            removeSpan.textContent = '×';
+                            removeSpan.addEventListener('click', function(event) {
                                 event.stopPropagation();
                                 removeService(service);
                             });
 
+                            button.appendChild(removeSpan);
                             cell.appendChild(button);
                         }
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/12](https://github.com/tommichael88/booktomnyc/security/code-scanning/12)

To fix the issue, we need to ensure that user input is properly escaped before being inserted into the DOM. Instead of using `innerHTML`, which interprets the input as HTML, we should use `textContent` to safely insert the user input as plain text. This prevents any HTML or JavaScript from being executed. 

The changes will involve replacing the use of `innerHTML` with `textContent` for the user message content on line 233. Additionally, we will ensure that the bot's response, which is generated internally, remains safe by keeping its current usage of `innerHTML`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
