### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/QQB_CHAT_MESSAGES_SMS.html
+++ b/QQB_CHAT_MESSAGES_SMS.html
@@ -230,10 +230,14 @@
                 var messagesDiv = document.getElementById('messages');
                 var userMessageDiv = document.createElement('div');
                 userMessageDiv.className = 'message user-message';
-                userMessageDiv.innerHTML = `
-                    <div class="message-content">${userInput.value}</div>
-                    <div class="timestamp">${getCurrentTime()}</div>
-                `;
+                const userMessageContent = document.createElement('div');
+                userMessageContent.className = 'message-content';
+                userMessageContent.textContent = userInput.value;
+                const userMessageTimestamp = document.createElement('div');
+                userMessageTimestamp.className = 'timestamp';
+                userMessageTimestamp.textContent = getCurrentTime();
+                userMessageDiv.appendChild(userMessageContent);
+                userMessageDiv.appendChild(userMessageTimestamp);
                 messagesDiv.appendChild(userMessageDiv);
 
                 document.getElementById('bot-typing').style.display = "block";

--- a/qr_11.html
+++ b/qr_11.html
@@ -596,12 +596,17 @@
 
                             const button = document.createElement('button');
                             button.className = 'selected-service-btn';
-                            button.innerHTML = `${specificService} <span class="remove-service">×</span>`;
-                            button.querySelector('.remove-service').addEventListener('click', function(event) {
+                            button.textContent = specificService;
+
+                            const removeSpan = document.createElement('span');
+                            removeSpan.className = 'remove-service';
+                            removeSpan.textContent = '×';
+                            removeSpan.addEventListener('click', function(event) {
                                 event.stopPropagation();
                                 removeService(service);
                             });
 
+                            button.appendChild(removeSpan);
                             cell.appendChild(button);
                         }
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/14](https://github.com/tommichael88/booktomnyc/security/code-scanning/14)

To fix the issue, we need to ensure that untrusted data is not directly interpreted as HTML. Instead of using `innerHTML`, we can use `textContent` for the `specificService` part to prevent it from being treated as HTML. For the static HTML content (`<span class="remove-service">×</span>`), we can create the span element programmatically and append it to the button. This approach avoids any potential XSS vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
