### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/qr_092524.html
+++ b/qr_092524.html
@@ -649,12 +649,15 @@
 
                             const button = document.createElement('button');
                             button.className = 'selected-service-btn';
-                            button.innerHTML = `${specificService} <span class="remove-service">×</span>`;
-                            button.querySelector('.remove-service').addEventListener('click', function(event) {
+                            button.textContent = specificService;
+                            const removeSpan = document.createElement('span');
+                            removeSpan.className = 'remove-service';
+                            removeSpan.textContent = '×';
+                            removeSpan.addEventListener('click', function(event) {
                                 event.stopPropagation();
                                 removeService(service);
                             });
-
+                            button.appendChild(removeSpan);
                             cell.appendChild(button);
                         }
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/13](https://github.com/tommichael88/booktomnyc/security/code-scanning/13)

To fix the issue, we should avoid using `innerHTML` to set the button's content. Instead, we can use `textContent` for the `specificService` part to ensure that it is treated as plain text, and then append the `span` element programmatically. This approach prevents any untrusted data from being interpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
