### PR TITLE
Potential fix for code scanning alert no. 38: DOM text reinterpreted as HTML

### DIFF
--- a/cat_light.html
+++ b/cat_light.html
@@ -1551,10 +1551,19 @@ function performSearch(query) {
             if (!selectedItem) return;
             const selectedFurnitureList = document.getElementById('selectedFurnitureList');
             const li = document.createElement('li');
-            li.innerHTML = `<span>${selectedItem}</span>
-                      <button class="remove-item" onclick="this.parentElement.remove(); removeFurnitureItem('${selectedItem}');">
-                        <i class="fas fa-times"></i>
-                      </button>`;
+            const span = document.createElement('span');
+            span.textContent = selectedItem;
+            const button = document.createElement('button');
+            button.className = "remove-item";
+            button.onclick = function () {
+                this.parentElement.remove();
+                removeFurnitureItem(selectedItem);
+            };
+            const icon = document.createElement('i');
+            icon.className = "fas fa-times";
+            button.appendChild(icon);
+            li.appendChild(span);
+            li.appendChild(button);
             selectedFurnitureList.appendChild(li);
             state.furnitureItems.push(selectedItem);
             furnitureSelect.value = "";


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/38](https://github.com/tommichael88/booktomnyc/security/code-scanning/38)

To fix the issue, we should avoid using `innerHTML` to insert untrusted data into the DOM. Instead, we can use `textContent` to safely insert the `selectedItem` value as plain text. This ensures that any special characters in the `selectedItem` value are escaped and cannot be interpreted as HTML or JavaScript. Additionally, we can create the button and its child elements programmatically using DOM methods to avoid any reliance on HTML strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
