### PR TITLE
Potential fix for code scanning alert no. 23: DOM text reinterpreted as HTML

### DIFF
--- a/js/service-handler.js
+++ b/js/service-handler.js
@@ -168,10 +168,14 @@
                                     serviceContent.style.display = 'flex';
                                     serviceContent.style.justifyContent = 'space-between';
                                     serviceContent.style.alignItems = 'center';
-                                    serviceContent.innerHTML = `
-                <span>${serviceIcon} ${service}</span>
-                <button class="remove-service">❌</button>
-            `;
+                                    const serviceText = document.createElement('span');
+                                    serviceText.textContent = `${service}`;
+                                    serviceText.insertAdjacentHTML('afterbegin', `${serviceIcon} `);
+                                    const removeButton = document.createElement('button');
+                                    removeButton.className = 'remove-service';
+                                    removeButton.textContent = '❌';
+                                    serviceContent.appendChild(serviceText);
+                                    serviceContent.appendChild(removeButton);
                                     // Nested furniture list (only for Furniture Fixes)
                                     if (service.startsWith('Furniture Fixes') && furnitureItems[service]?.length > 0) {
                                         const furnitureList = document.createElement('ul');


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/23](https://github.com/tommichael88/booktomnyc/security/code-scanning/23)

To fix the issue, we need to ensure that any untrusted data inserted into the DOM is properly sanitized or escaped. Instead of using `innerHTML`, which interprets the string as HTML, we can use `textContent` to safely insert the data as plain text. This approach prevents the browser from interpreting the data as HTML, thereby mitigating the XSS risk.

Specifically:
1. Replace the use of `innerHTML` on line 171 with `textContent` for the `service` variable.
2. For the `serviceIcon`, which is a trusted value from the `serviceIcons` object, we can safely concatenate it with the sanitized `service` text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
