### PR TITLE
Potential fix for code scanning alert no. 32: DOM text reinterpreted as HTML

### DIFF
--- a/catframe3.html
+++ b/catframe3.html
@@ -965,8 +965,13 @@
                                             let mainService = (serviceParts.length > 1) ? serviceParts[1] : serviceParts[0];
                                             let serviceIcon = serviceIcons[mainService] || '🔧';
 
-                                            listItem.innerHTML = '<span>' + serviceIcon + ' ' + service + '</span>' +
-                                                '<button class="remove-service">❌</button>';
+                                            let span = document.createElement('span');
+                                            span.textContent = serviceIcon + ' ' + service;
+                                            let removeButton = document.createElement('button');
+                                            removeButton.className = 'remove-service';
+                                            removeButton.textContent = '❌';
+                                            listItem.appendChild(span);
+                                            listItem.appendChild(removeButton);
 
                                             // If this is a Furniture Fixes service with associated furniture items, list them.
                                             if (service.indexOf('Furniture Fixes') === 0 && furnitureItems[service] && furnitureItems[service].length > 0) {
@@ -974,8 +979,13 @@
                                                 furnitureList.className = 'nested-furniture-list';
                                                 furnitureItems[service].forEach(function(item) {
                                                     let furnitureItem = document.createElement('li');
-                                                    furnitureItem.innerHTML = '<span>' + item + '</span>' +
-                                                        '<button class="remove-furniture">❌</button>';
+                                                    let span = document.createElement('span');
+                                                    span.textContent = item;
+                                                    let removeButton = document.createElement('button');
+                                                    removeButton.className = 'remove-furniture';
+                                                    removeButton.textContent = '❌';
+                                                    furnitureItem.appendChild(span);
+                                                    furnitureItem.appendChild(removeButton);
                                                     furnitureItem.querySelector('.remove-furniture').addEventListener('click', function() {
                                                         furnitureItems[service] = furnitureItems[service].filter(function(i) {
                                                             return i !== item;


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/32](https://github.com/tommichael88/booktomnyc/security/code-scanning/32)

To fix the issue, we need to ensure that any untrusted data (like `service` and `item`) is properly escaped before being inserted into the DOM. Instead of using `innerHTML`, which interprets the string as HTML, we should use `textContent` for plain text or create DOM elements programmatically. This approach prevents the browser from interpreting the data as HTML, mitigating the XSS risk.

Specifically:
1. Replace the use of `innerHTML` on lines 968 and 977 with safe alternatives.
2. Use `textContent` to set plain text content for the `span` elements.
3. Create the `button` elements programmatically and set their properties directly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
