### PR TITLE
Potential fix for code scanning alert no. 35: DOM text reinterpreted as HTML

### DIFF
--- a/cat_light5.html
+++ b/cat_light5.html
@@ -1358,10 +1358,17 @@
       if (!selectedItem) return;
       const selectedFurnitureList = document.getElementById('selectedFurnitureList');
       const li = document.createElement('li');
-      li.innerHTML = `<span>${selectedItem}</span>
-                      <button class="remove-item" onclick="this.parentElement.remove(); removeFurnitureItem('${selectedItem}');">
-                        <i class="fas fa-times"></i>
-                      </button>`;
+      const span = document.createElement('span');
+      span.textContent = selectedItem;
+      const button = document.createElement('button');
+      button.className = "remove-item";
+      button.innerHTML = '<i class="fas fa-times"></i>';
+      button.onclick = function () {
+        this.parentElement.remove();
+        removeFurnitureItem(selectedItem);
+      };
+      li.appendChild(span);
+      li.appendChild(button);
       selectedFurnitureList.appendChild(li);
       state.furnitureItems.push(selectedItem);
       furnitureSelect.value = "";


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/35](https://github.com/tommichael88/booktomnyc/security/code-scanning/35)

To fix the issue, we should avoid using `innerHTML` to insert untrusted data into the DOM. Instead, we can use `textContent` or `createElement` to ensure that any special characters in the `selectedItem` value are properly escaped. This approach prevents the interpretation of the string as HTML, thereby mitigating the XSS vulnerability.

Specifically:
1. Replace the use of `innerHTML` on line 1361 with DOM manipulation methods like `createElement` and `textContent`.
2. Ensure that the `selectedItem` value is safely added to the DOM as plain text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
