### PR TITLE
Potential fix for code scanning alert no. 28: DOM text reinterpreted as HTML

### DIFF
--- a/qr.html
+++ b/qr.html
@@ -1259,8 +1259,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 let mainService = (serviceParts.length > 1) ? serviceParts[1] : serviceParts[0];
                 let serviceIcon = serviceIcons[mainService] || '🔧';
 
-                listItem.innerHTML = '<span>' + serviceIcon + ' ' + service + '</span>' +
-                                     '<button class="remove-service">❌</button>';
+                let span = document.createElement('span');
+                span.textContent = service; // Safely set the service text
+                span.insertAdjacentText('afterbegin', serviceIcon + ' '); // Prepend the trusted serviceIcon
+
+                let removeButton = document.createElement('button');
+                removeButton.className = 'remove-service';
+                removeButton.textContent = '❌'; // Safely set the button text
+
+                listItem.appendChild(span);
+                listItem.appendChild(removeButton);
 
                 // If this is a Furniture Fixes service with associated furniture items, list them.
                 if (service.indexOf('Furniture Fixes') === 0 && furnitureItems[service] && furnitureItems[service].length > 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/28](https://github.com/tommichael88/booktomnyc/security/code-scanning/28)

To fix the issue, we should avoid directly assigning untrusted data to `innerHTML`. Instead, we can use `textContent` to safely insert text into the DOM, ensuring that any special characters are properly escaped. For the `serviceIcon`, which is a trusted source (presumably defined in the `serviceIcons` object), we can safely append it as part of the DOM structure.

Specifically:
1. Replace the concatenation of `serviceIcon` and `service` into an HTML string with the creation of separate DOM elements for the icon and the service text.
2. Use `textContent` to safely insert the `service` text into the DOM.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
