### PR TITLE
Potential fix for code scanning alert no. 29: DOM text reinterpreted as HTML

### DIFF
--- a/cat.html
+++ b/cat.html
@@ -1123,10 +1123,17 @@
       if (!selectedItem) return;
       const selectedFurnitureList = document.getElementById('selectedFurnitureList');
       const li = document.createElement('li');
-      li.innerHTML = `<span>${selectedItem}</span>
-                      <button class="remove-item" onclick="this.parentElement.remove(); removeFurnitureItem('${selectedItem}');">
-                        <i class="fas fa-times"></i>
-                      </button>`;
+      const span = document.createElement('span');
+      span.textContent = selectedItem;
+      const button = document.createElement('button');
+      button.className = "remove-item";
+      button.innerHTML = '<i class="fas fa-times"></i>';
+      button.onclick = function() {
+        this.parentElement.remove();
+        removeFurnitureItem(selectedItem);
+      };
+      li.appendChild(span);
+      li.appendChild(button);
       selectedFurnitureList.appendChild(li);
       state.furnitureItems.push(selectedItem);
       furnitureSelect.value = "";


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/29](https://github.com/tommichael88/booktomnyc/security/code-scanning/29)

To fix the issue, we should avoid using `innerHTML` to insert untrusted data into the DOM. Instead, we can use `textContent` or create DOM elements programmatically to ensure that any special characters in the `selectedItem` value are treated as plain text rather than HTML. This approach eliminates the risk of XSS by preventing the browser from interpreting the input as HTML.

Specifically, in the `addFurnitureItem` function:
1. Replace the use of `innerHTML` with programmatic creation of DOM elements.
2. Use `textContent` to safely insert the `selectedItem` value into the DOM.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
