### PR TITLE
Potential fix for code scanning alert no. 31: DOM text reinterpreted as HTML

### DIFF
--- a/catframe2.html
+++ b/catframe2.html
@@ -966,8 +966,13 @@
                                             let mainService = (serviceParts.length > 1) ? serviceParts[1] : serviceParts[0];
                                             let serviceIcon = serviceIcons[mainService] || '🔧';
 
-                                            listItem.innerHTML = '<span>' + serviceIcon + ' ' + service + '</span>' +
-                                                '<button class="remove-service">❌</button>';
+                                            let span = document.createElement('span');
+                                            span.textContent = serviceIcon + ' ' + service;
+                                            let button = document.createElement('button');
+                                            button.className = 'remove-service';
+                                            button.textContent = '❌';
+                                            listItem.appendChild(span);
+                                            listItem.appendChild(button);
 
                                             // If this is a Furniture Fixes service with associated furniture items, list them.
                                             if (service.indexOf('Furniture Fixes') === 0 && furnitureItems[service] && furnitureItems[service].length > 0) {
@@ -975,8 +980,13 @@
                                                 furnitureList.className = 'nested-furniture-list';
                                                 furnitureItems[service].forEach(function(item) {
                                                     let furnitureItem = document.createElement('li');
-                                                    furnitureItem.innerHTML = '<span>' + item + '</span>' +
-                                                        '<button class="remove-furniture">❌</button>';
+                                                    let span = document.createElement('span');
+                                                    span.textContent = item;
+                                                    let button = document.createElement('button');
+                                                    button.className = 'remove-furniture';
+                                                    button.textContent = '❌';
+                                                    furnitureItem.appendChild(span);
+                                                    furnitureItem.appendChild(button);
                                                     furnitureItem.querySelector('.remove-furniture').addEventListener('click', function() {
                                                         furnitureItems[service] = furnitureItems[service].filter(function(i) {
                                                             return i !== item;


### PR DESCRIPTION
Potential fix for [https://github.com/tommichael88/booktomnyc/security/code-scanning/31](https://github.com/tommichael88/booktomnyc/security/code-scanning/31)

To fix the issue, we need to ensure that any untrusted data (like `service`) is properly escaped before being inserted into the DOM using `innerHTML`. Instead of directly concatenating strings, we can use `textContent` or `createTextNode` to safely handle text. This approach ensures that special characters are escaped and prevents XSS attacks.

Specifically:
1. Replace the use of `innerHTML` on line 969 with DOM manipulation methods that safely handle text.
2. Similarly, replace the use of `innerHTML` on line 978 for `furnitureItem`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
